### PR TITLE
Lots of changes here and there needed for Overseer

### DIFF
--- a/components/DropdownMenu.svelte
+++ b/components/DropdownMenu.svelte
@@ -1,13 +1,13 @@
 <style>
-	.shift-left {
-		transform: translateX(-100%);
+	.dropdown-menu :global(ul) {
+		list-style: none;
+	}
+	.dropdown-menu :global(button) {
+		color: white;
+		text-align: left;
 	}
 </style>
 
-<div class="dropdown-menu f-column" class:shift-left={shiftLeft}>
+<div class="dropdown-menu f-column">
 	<slot />
 </div>
-
-<script>
-	export let shiftLeft = false;
-</script>

--- a/components/MenuButton.svelte
+++ b/components/MenuButton.svelte
@@ -1,0 +1,45 @@
+<style>
+    button {
+        color: white;
+    }
+    .menubutton-menu {
+        z-index: 1000;
+    }
+</style>
+
+<button on:click|stopPropagation={() => showDropdown = !showDropdown} bind:this={button}>
+    <slot name="trigger" />
+</button>
+{#if showDropdown}
+    <div on:click={() => showDropdown = false} use:positionMenu bind:this={menu} class="menubutton-menu">
+        <DropdownMenu>
+            <slot name="menu" />
+        </DropdownMenu>
+    </div>
+{/if}
+
+<svelte:body on:click={maybeClose} />
+
+<script>
+    import {createPopper} from '@popperjs/core';
+    import DropdownMenu from './DropdownMenu.svelte';
+
+    //popperjs placement option
+    export let placement = 'bottom-start';
+
+    let showDropdown = false,
+        button,
+        menu;
+
+    function positionMenu(menu) {
+        createPopper(button, menu, {
+            placement
+        })
+    }
+
+    function maybeClose(e) {
+        if (showDropdown && menu && !menu.contains(e.target)) {
+            showDropdown = false;
+        }
+    }
+</script>

--- a/components/Modal.svelte
+++ b/components/Modal.svelte
@@ -19,6 +19,7 @@
         display: flex;
         flex-direction: column;
         max-height: 90vh;
+		border: var(--panel-border);
     }
     .modal-title {
         display: flex;

--- a/components/Toast.svelte
+++ b/components/Toast.svelte
@@ -34,16 +34,26 @@
 			<span class="sr-only">Clear Toast</span>
 		</button>
 	</div>
-	<p class="message">{toast.message}</p>
+    <p class="message">
+		{#if toast.href}
+			<a href={toast.href}>{toast.message}</a>
+		{:else}
+			{toast.message}
+		{/if}
+	</p>
 	{#if toast.technicalDetails}
 		<pre>
 			{toast.technicalDetails}
 		</pre>
 	{/if}
+	{#if toast.progress}
+		<Progress max={toast.max} min={toast.min} value={toast.value} id="toast-progress-id-{toast.id}" />
+	{/if}
 </div>
 
 <script>
 	import {clearToast} from './toast';
+	import Progress from './Progress.svelte';
 	import Icon from './Icon.svelte';
 
 	export let toast;

--- a/components/Toasts.svelte
+++ b/components/Toasts.svelte
@@ -7,8 +7,8 @@
 		z-index: 10001;
 	}
 	.top-right {
+		/* implicitly "top: 0" allows toasts to be positioned below the header by putting it in the page's <main> */
         right: 0;
-        top: 0;
 	}
 	.bottom-center {
 		bottom: 0;

--- a/components/toast.js
+++ b/components/toast.js
@@ -65,7 +65,15 @@ export function createAutoExpireToast(options) {
 		title: options.title,
 		message: options.message || '',
 		technicalDetails: options.technicalDetails,
-		variant: options.variant || 'info'
+		variant: options.variant || 'info',
+		href: options.href,
+        //toasts with a progress bar have additional options
+		...(options.progress ? {
+			min: options.min,
+			max: options.max,
+			value: options.value || 0,
+			progress: true
+		} : {})
 	})
 
 	return id;
@@ -75,6 +83,29 @@ export function createPersistentToast(options) {
 	return createAutoExpireToast(Object.assign(options, {
 		ttl: Infinity
 	}))
+}
+
+export function createProgressToast(options) {
+	return createAutoExpireToast({
+		//expecting all the same options as a normal toast, plus a "min" and "max"
+		...options,
+		progress: true,
+	});
+}
+
+export function updateToast(id, updates) {
+	toasts.update(toasts => {
+		return toasts.map(toast => {
+			if (toast.id === id) {
+				//keep this toast around until it stops updating,
+				//can be used for long running things like uploads
+				toast.ttl = toast.initialTTL;
+				//allow any arbitrary properties to be updated
+				Object.assign(toast, updates);
+			}
+			return toast;
+		})
+	})
 }
 
 export function clearToast(id) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
 	Footer: require('./components/Footer.svelte').default,
 	DropdownMenu: require('./components/DropdownMenu.svelte').default,
 	NavDropdown: require('./components/NavDropdown.svelte').default,
+	MenuButton: require('./components/MenuButton.svelte').default,
 	ButtonDropdown: require('./components/ButtonDropdown.svelte').default,
 	Loading: require('./components/Loading.svelte').default,
 	TabList: require('./components/TabList.svelte').default,
@@ -17,5 +18,7 @@ module.exports = {
 	//expose only public toast methods
 	createAutoExpireToast: toastUtils.createAutoExpireToast,
 	createPersistentToast: toastUtils.createPersistentToast,
+	createProgressToast: toastUtils.createProgressToast,
+	updateToast: toastUtils.updateToast,
 	clearToast: toastUtils.clearToast,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@popperjs/core": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.1.tgz",
+      "integrity": "sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA=="
+    },
     "normalize.css": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "sheodox",
   "license": "ISC",
   "dependencies": {
+    "@popperjs/core": "^2.9.1",
     "normalize.css": "^8.0.1"
   },
   "repository": {

--- a/style/components/_dropdown-menu.scss
+++ b/style/components/_dropdown-menu.scss
@@ -1,7 +1,4 @@
 .dropdown-menu {
-    position: absolute;
-    z-index: 100;
-    width: 100%;
     box-shadow: 0 0 0.4rem black;
     background: var(--panel-header-bg);
 
@@ -12,7 +9,7 @@
         flex-direction: column;
 
         li a, li .a {
-            padding: 0.5rem;
+            padding: 0.7rem;
             border: none;
             color: white;
             background: none;

--- a/style/components/_modal.scss
+++ b/style/components/_modal.scss
@@ -3,3 +3,12 @@
   flex: 1;
   overflow: auto;
 }
+.modal-footer {
+  display: flex;
+  justify-content: end;
+  padding: 0.5rem;
+
+  button {
+    margin: 0.5rem;
+  }
+}

--- a/style/components/_panel.scss
+++ b/style/components/_panel.scss
@@ -3,8 +3,12 @@
     padding: 0;
     margin: 0;
 
-    .panel-body {
+    .panel-body, &.panel-body {
         padding: 1rem;
+    }
+
+    &.bordered {
+        border: var(--panel-border);
     }
 }
 .sub-panel {

--- a/style/elements/_button.scss
+++ b/style/elements/_button.scss
@@ -56,6 +56,6 @@ button.danger:not(:disabled) {
     }
 }
 
-button.small {
+button.small, .button.small {
     padding: 0.3rem;
 }

--- a/style/elements/_header.scss
+++ b/style/elements/_header.scss
@@ -42,6 +42,10 @@
                 border-bottom-color: transparent !important;
                 background-color: var(--panel-header-bg-dark);
             }
+
+            &.active {
+                border-color: var(--accent-purple-bright);
+            }
         }
 
         .dropdown-menu {

--- a/style/elements/_input.scss
+++ b/style/elements/_input.scss
@@ -30,6 +30,11 @@ input[type=text], input:not([type]), textarea, select {
     border: 1px solid var(--input-bg);
     display: flex;
 
+    label {
+        align-self: center;
+        padding: 0.2rem;
+    }
+
     input {
         border: 1px solid transparent;
     }

--- a/style/elements/_table.scss
+++ b/style/elements/_table.scss
@@ -1,8 +1,12 @@
 table {
   border-collapse: collapse;
+
+  &.hoverable tbody tr:hover {
+    background: #5766a221;
+  }
 }
 th {
-  background: #6f4f7721;
+  background: #5766a221;
 }
 td, th {
   padding: 0.2rem 0.5rem;

--- a/style/utility/_flex.scss
+++ b/style/utility/_flex.scss
@@ -34,6 +34,22 @@
     align-items: end;
 }
 
+.align-self-start {
+    align-self: start;
+}
+.align-self-center {
+    align-self: center;
+}
+.align-self-end {
+    align-self: end;
+}
+
 .f-wrap {
     flex-wrap: wrap;
+}
+
+@for $i from 0 through 5 {
+    .f-#{$i} {
+        flex: #{$i};
+    }
 }

--- a/style/utility/_text.scss
+++ b/style/utility/_text.scss
@@ -1,3 +1,21 @@
 .muted {
     color: var(--muted);
 }
+
+.fw-bold {
+    font-weight: bold;
+}
+
+.fw-normal {
+    font-weight: normal;
+}
+
+.text-align-center {
+    text-align: center;
+}
+.text-align-left {
+    text-align: left;
+}
+.text-align-right {
+    text-align: right;
+}

--- a/style/utility/_variables.scss
+++ b/style/utility/_variables.scss
@@ -20,7 +20,7 @@
     $base: #05070b;
     --bg: #{$base};
     --panel-bg: #0c0e15;
-    --sub-panel-bg: #{lighten($base, 6%)};
+    --sub-panel-bg: #181d2d;
     --panel-border-color: #8c8c8c21;
     --panel-border: 1px solid var(--panel-border-color);
     $header: #1c1f28;


### PR DESCRIPTION
It's a bigger app than any of the other things using sheodox-ui so it needed a lot of things!

I've added a new MenuButton component, it lets you have a popup menu of options that show when you click a button. It's a pattern used elsewhere but now it's an official component because it's tricky getting it to show/hide at the right times. The positioning of something generic like this is a pain with just CSS so I added popper.js to handle positioning the popup.

Tons of other tiny changes:
* Several flexbox related utilities (align-self: start/center/end, and flex: 1 through flex: 5) and font weight/text align utility classes were added.
* Tables can now add a .hoverable class to show a row highlight on hover.
* TH cells have a more fitting background color.
* Labels in input groups are now vertically centered and padded by default.
* Header nav links can now have a .active class which shows a pink border on it to indicate the current page.
* Panels can now get some padding by adding a .panel-body class to it (not just to an element it contains) and the panel border can be applied on all sides by adding .bordered.
* Modals now have a .modal-footer class you can use which will right align a row of buttons.
* The sub panel bg now has a color that more matches the color scheme elsewhere.
* Modals now use the panel border, they were (and probably still are) hard to see on low contrast displays.

Toasts now support progress bars and links. If an href is provided in the toast options it'll make the message into a link. When creating a progress toast you can call the new updateToast method to overwrite any needed options.